### PR TITLE
Correction de la doc, sur la callback "canXXX" (canAccept)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ class Article implements Stateful
         // your logic here
     }
 
-    public function canAccept()
+    public function onCanAccept()
     {
         // your logic here
     }


### PR DESCRIPTION
Ligne 46 du statefulEntitiesCallbacksListener :
$result = $this->callCallback($object, 'onCan', $event->getTransition()->getName());

On recherche des méthodes commençant par onCanXXX et non pas canXXX
Corrigé dans la doc.