### PR TITLE
Changes on Twig extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,12 +209,12 @@ The bundle also exposes a few Twig helpers:
     </a>
 {% endif %}
 
-{% if article|isStatus('rejected') %}
+{% if article|is_status('rejected') %}
     blabla
 {% endif %}
 
 {# this is strictly equivalent #}
-{% if isStatus(article, 'rejected') %}
+{% if is_status(article, 'rejected') %}
     blabla
 {% endif %}
 ```

--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ The bundle also exposes a few Twig helpers:
 {% if is_status(article, 'rejected') %}
     blabla
 {% endif %}
+
+{% if article|has_property('printable') %}
+    {{ article|property('printable') ? 'I can print' : 'I CANNOT print' }}
+{% endif %}
+
+{# this is strictly equivalent #}
+{% if has_property(article, 'printable') %}
+    {{ property(article, 'printable') ? 'I can print' : 'I CANNOT print' }}
+{% endif %}
 ```
 
 

--- a/Twig/StateMachineExtension.php
+++ b/Twig/StateMachineExtension.php
@@ -14,9 +14,9 @@ class StateMachineExtension extends \Twig_Extension
         return array(
             new \Twig_SimpleFunction('can', array($this, 'can')),
             new \Twig_SimpleFunction('is_status', array($this, 'isStatus')),
-            // undocumented
             new \Twig_SimpleFunction('has_property', array($this, 'hasProperty')),
             new \Twig_SimpleFunction('property', array($this, 'getProperty')),
+            // undocumented
             new \Twig_SimpleFunction('current_state', array($this, 'getCurrentState')),
         );
     }
@@ -26,9 +26,9 @@ class StateMachineExtension extends \Twig_Extension
         return array(
             'can'           => new \Twig_Filter_Method($this, 'can'),
             'is_status'     => new \Twig_Filter_Method($this, 'isStatus'),
-            // undocumented
             'has_property'  => new \Twig_Filter_Method($this, 'hasProperty'),
             'property'  => new \Twig_Filter_Method($this, 'getProperty'),
+            // undocumented
             'current_state' => new \Twig_Filter_Method($this, 'getCurrentState'),
         );
     }

--- a/Twig/StateMachineExtension.php
+++ b/Twig/StateMachineExtension.php
@@ -13,6 +13,7 @@ class StateMachineExtension extends \Twig_Extension
     {
         return array(
             new \Twig_SimpleFunction('can', array($this, 'can')),
+            new \Twig_SimpleFunction('isStatus', array($this, 'isStatusCamelCase')), // @deprecated
             new \Twig_SimpleFunction('is_status', array($this, 'isStatus')),
             new \Twig_SimpleFunction('has_property', array($this, 'hasProperty')),
             new \Twig_SimpleFunction('property', array($this, 'getProperty')),
@@ -25,9 +26,10 @@ class StateMachineExtension extends \Twig_Extension
     {
         return array(
             'can'           => new \Twig_Filter_Method($this, 'can'),
+            'isStatus'      => new \Twig_Filter_Method($this, 'isStatusCamelCase'), // @deprecated
             'is_status'     => new \Twig_Filter_Method($this, 'isStatus'),
             'has_property'  => new \Twig_Filter_Method($this, 'hasProperty'),
-            'property'  => new \Twig_Filter_Method($this, 'getProperty'),
+            'property'      => new \Twig_Filter_Method($this, 'getProperty'),
             // undocumented
             'current_state' => new \Twig_Filter_Method($this, 'getCurrentState'),
         );
@@ -36,6 +38,13 @@ class StateMachineExtension extends \Twig_Extension
     public function can($entity, $transition)
     {
         return $this->getCurrentState($entity)->can($transition);
+    }
+
+    public function isStatusCamelCase($entity, $status)
+    {
+        @trigger_error(get_class($this).': The "isStatus" call is deprecated, use "is_status" instead.', E_USER_DEPRECATED);
+
+        return $this->isStatus($entity, $status);
     }
 
     public function isStatus($entity, $status)

--- a/Twig/StateMachineExtension.php
+++ b/Twig/StateMachineExtension.php
@@ -13,34 +13,53 @@ class StateMachineExtension extends \Twig_Extension
     {
         return array(
             new \Twig_SimpleFunction('can', array($this, 'can')),
-            new \Twig_SimpleFunction('isStatus', array($this, 'isStatus')),
+            new \Twig_SimpleFunction('is_status', array($this, 'isStatus')),
+            // undocumented
+            new \Twig_SimpleFunction('has_property', array($this, 'hasProperty')),
+            new \Twig_SimpleFunction('property', array($this, 'getProperty')),
+            new \Twig_SimpleFunction('current_state', array($this, 'getCurrentState')),
         );
     }
 
     public function getFilters()
     {
         return array(
-            'can'       => new \Twig_Filter_Method($this, 'can'),
-            'isStatus'  => new \Twig_Filter_Method($this, 'isStatus'),
+            'can'           => new \Twig_Filter_Method($this, 'can'),
+            'is_status'     => new \Twig_Filter_Method($this, 'isStatus'),
+            // undocumented
+            'has_property'  => new \Twig_Filter_Method($this, 'hasProperty'),
+            'property'  => new \Twig_Filter_Method($this, 'getProperty'),
+            'current_state' => new \Twig_Filter_Method($this, 'getCurrentState'),
         );
     }
 
     public function can($entity, $transition)
     {
-        if (!$entity instanceof Stateful) {
-            throw new \RuntimeException(sprintf('Expected Stateful object, %s given', get_class($entity)));
-        }
-
-        return $entity->getStateMachine()->can($transition);
+        return $this->getCurrentState($entity)->can($transition);
     }
 
-    public function isStatus($entity, $state)
+    public function isStatus($entity, $status)
+    {
+        return $this->getCurrentState($entity)->getName() === $status;
+    }
+
+    public function hasProperty($entity, $property)
+    {
+        return $this->getCurrentState($entity)->has($property);
+    }
+
+    public function getProperty($entity, $property)
+    {
+        return $this->getCurrentState($entity)->get($property);
+    }
+
+    public function getCurrentState($entity)
     {
         if (!$entity instanceof Stateful) {
             throw new \RuntimeException(sprintf('Expected Stateful object, %s given', get_class($entity)));
         }
 
-        return $entity->getStateMachine()->getCurrentState()->getName() === $state;
+        return $entity->getStateMachine()->getCurrentState();
     }
 
     public function getName()


### PR DESCRIPTION
Hi! I have some pull request to submit (I needed some time to split them).

The first one is some changes to Twig functions and filters.
 - I renamed previous functions/filters according to Twig coding standard (underscore instead of camelcase for functions/filters. It doesn't appear in the official documentation but it seems a common standard) [BC-BREAK]
 - 2 new functions/filters to retrieve state properties + 1 additional undocumented function/filter to get current State object

If you like the idea but don't like the BC break, it is possible to leave the previous methods but use the new names in the doc.