### PR TITLE
Handle object deserialization

### DIFF
--- a/DependencyInjection/KPhoenDoctrineStateMachineExtension.php
+++ b/DependencyInjection/KPhoenDoctrineStateMachineExtension.php
@@ -37,13 +37,11 @@ class KPhoenDoctrineStateMachineExtension extends Extension
 
         // disable useless listeners
         if (!$config['auto_injection']) {
-            $container->getDefinition('kphoen.state_machine.listener.injection')
-                ->clearTag('doctrine.event_subscriber');
+            $container->removeDefinition('kphoen.state_machine.listener.injection');
         }
 
         if (!$config['auto_validation']) {
-            $container->getDefinition('kphoen.state_machine.listener.persistence')
-                ->clearTag('doctrine.event_subscriber');
+            $container->removeDefinition('kphoen.state_machine.listener.persistence');
         }
     }
 

--- a/Listener/InjectionListener.php
+++ b/Listener/InjectionListener.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace KPhoen\DoctrineStateMachineBundle\Listener;
+
+use KPhoen\DoctrineStateMachineBehavior\Listener\InjectionListener as BaseInjectionListener;
+use Doctrine\Common\Util\ClassUtils;
+use JMS\Serializer\EventDispatcher\ObjectEvent;
+use KPhoen\DoctrineStateMachineBehavior\Entity\Stateful;
+
+/**
+ * Injects the state machines into stateful entities when they are loaded by
+ * Doctrine or JMSSerializer.
+ */
+class InjectionListener extends BaseInjectionListener
+{
+    public function onPostDeserialize(ObjectEvent $event)
+    {
+        $entity = $event->getObject();
+
+        if (!$entity instanceof Stateful) {
+            return;
+        }
+
+        $this->injectStateMachine($entity);
+    }
+}

--- a/Resources/config/listeners.yml
+++ b/Resources/config/listeners.yml
@@ -1,6 +1,6 @@
 parameters:
     kphoen.state_machine.listener.persistence.class: KPhoen\DoctrineStateMachineBehavior\Listener\PersistenceListener
-    kphoen.state_machine.listener.injection.class: KPhoen\DoctrineStateMachineBehavior\Listener\InjectionListener
+    kphoen.state_machine.listener.injection.class: KPhoen\DoctrineStateMachineBundle\Listener\InjectionListener
     kphoen.state_machine.listener.callbacks.class: KPhoen\DoctrineStateMachineBehavior\Listener\StatefulEntitiesCallbacksListener
 
 services:
@@ -16,6 +16,7 @@ services:
         arguments:  [ @kphoen.state_machine.factory ]
         tags:
             - { name: doctrine.event_subscriber }
+            - { name: jms_serializer.event_listener, event: serializer.post_deserialize, method: onPostDeserialize }
 
     # finite listeners
     kphoen.state_machine.listener.callbacks:


### PR DESCRIPTION
With this pull request, the state machine can integrate fluently with jms serializer.

When an object is deserialized, the state machine is injected and can handle transitions, properties... It is handled with a service tag so the listener is not dependent on an external bundle.

no BC-BREAK !