### PR TITLE
Restrict state jumping to states reachable with transitions

### DIFF
--- a/Exception/AmbiguousJumpException.php
+++ b/Exception/AmbiguousJumpException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace KPhoen\DoctrineStateMachineBundle\Exception;
+
+use Finite\Exception\StateException;
+
+/**
+ * A state jump using an ambiguous transition generates an AmbiguousJumpException
+ */
+class AmbiguousJumpException extends StateException
+{
+}

--- a/Exception/NullJumpException.php
+++ b/Exception/NullJumpException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace KPhoen\DoctrineStateMachineBundle\Exception;
+
+use Finite\Exception\StateException;
+
+/**
+ * A state jump to the current state generates a NullJumpException
+ */
+class NullJumpException extends StateException
+{
+}

--- a/Resources/config/factories.yml
+++ b/Resources/config/factories.yml
@@ -1,7 +1,7 @@
 parameters:
     kphoen.state_machine.factory.class: KPhoen\DoctrineStateMachineBundle\Factory\Factory
     kphoen.state_machine.array_loader.class: Finite\Loader\ArrayLoader
-    kphoen.state_machine.class: KPhoen\DoctrineStateMachineBehavior\StateMachine\ExtendedStateMachine
+    kphoen.state_machine.class: KPhoen\DoctrineStateMachineBundle\StateMachine\ExtendedStateMachine
 
 services:
     kphoen.state_machine.factory:

--- a/StateMachine/ExtendedStateMachine.php
+++ b/StateMachine/ExtendedStateMachine.php
@@ -45,6 +45,11 @@ class ExtendedStateMachine extends BaseExtendedStateMachine
         // assert that the given state exists
         $this->getState($state);
 
+        // state jumping to current state is allowed as it does nothing
+        if ($this->currentState->getName() == $state) {
+            return true;
+        }
+
         $transitions = $this->getMatchingTransitions($this->currentState->getName(), $state);
 
         return count($transitions) == 1;
@@ -54,8 +59,6 @@ class ExtendedStateMachine extends BaseExtendedStateMachine
      * Moves to the given state if allowed.
      *
      * @param string|StateInterface $state
-     *
-     * @return bool
      */
     public function jumpToState($state)
     {
@@ -65,6 +68,11 @@ class ExtendedStateMachine extends BaseExtendedStateMachine
 
         if (!$this->canJumpToState($state)) {
             throw new StateException(sprintf('Can not jump from state "%s" to "%s".',$this->currentState->getName(), $state->getName()));
+        }
+
+        // do nothing if we try to jump to current state
+        if ($state == $this->currentState) {
+            return;
         }
 
         $transitions = $this->getMatchingTransitions($this->currentState->getName(), $state);

--- a/StateMachine/ExtendedStateMachine.php
+++ b/StateMachine/ExtendedStateMachine.php
@@ -50,7 +50,7 @@ class ExtendedStateMachine extends BaseExtendedStateMachine
 
         $matchingTransitions = $this->getMatchingTransitions($initialState, $targetedState);
 
-        if ($matchingTransitions != 1) {
+        if (count($matchingTransitions) != 1) {
             throw new AmbiguousJumpException();
         }
 

--- a/StateMachine/ExtendedStateMachine.php
+++ b/StateMachine/ExtendedStateMachine.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace KPhoen\DoctrineStateMachineBundle\StateMachine;
+
+use KPhoen\DoctrineStateMachineBehavior\StateMachine\ExtendedStateMachine as BaseExtendedStateMachine;
+use Finite\Exception\StateException;
+use Finite\State\StateInterface;
+
+class ExtendedStateMachine extends BaseExtendedStateMachine
+{
+    /**
+     * Find matching transitions between initial and targeted states.
+     *
+     * @param string $initialState
+     * @param string $targetedState
+     *
+     * @return array
+     */
+    private function getMatchingTransitions($initialState, $targetedState)
+    {
+        $matchingTransitions = array();
+
+        foreach($this->transitions as $transition) {
+            if ($transition->getState() == $targetedState && in_array($initialState, $transition->getInitialStates())) {
+                $matchingTransitions[] = $transition;
+            }
+        }
+
+        return $matchingTransitions;
+    }
+
+    /**
+     * Tells if moving to the given state is allowed.
+     *
+     * @param string|StateInterface $state
+     *
+     * @return bool
+     */
+    public function canJumpToState($state)
+    {
+        if ($state instanceof StateInterface) {
+            $state = $state->getName();
+        }
+
+        // assert that the given state exists
+        $this->getState($state);
+
+        $transitions = $this->getMatchingTransitions($this->currentState->getName(), $state);
+
+        return count($transitions) == 1;
+    }
+
+    /**
+     * Moves to the given state if allowed.
+     *
+     * @param string|StateInterface $state
+     *
+     * @return bool
+     */
+    public function jumpToState($state)
+    {
+        if (!$state instanceof StateInterface) {
+            $state = $this->getState($state);
+        }
+
+        if (!$this->canJumpToState($state)) {
+            throw new StateException(sprintf('Can not jump from state "%s" to "%s".',$this->currentState->getName(), $state->getName()));
+        }
+
+        $transitions = $this->getMatchingTransitions($this->currentState->getName(), $state);
+        $this->apply($transitions[0]->getName());
+    }
+}

--- a/StateMachine/ExtendedStateMachine.php
+++ b/StateMachine/ExtendedStateMachine.php
@@ -2,9 +2,12 @@
 
 namespace KPhoen\DoctrineStateMachineBundle\StateMachine;
 
-use KPhoen\DoctrineStateMachineBehavior\StateMachine\ExtendedStateMachine as BaseExtendedStateMachine;
 use Finite\Exception\StateException;
 use Finite\State\StateInterface;
+use Finite\Transition\TransitionInterface;
+use KPhoen\DoctrineStateMachineBehavior\StateMachine\ExtendedStateMachine as BaseExtendedStateMachine;
+use KPhoen\DoctrineStateMachineBundle\Exception\AmbiguousJumpException;
+use KPhoen\DoctrineStateMachineBundle\Exception\NullJumpException;
 
 class ExtendedStateMachine extends BaseExtendedStateMachine
 {
@@ -14,19 +17,44 @@ class ExtendedStateMachine extends BaseExtendedStateMachine
      * @param string $initialState
      * @param string $targetedState
      *
-     * @return array
+     * @return TransitionInterface[]
      */
     private function getMatchingTransitions($initialState, $targetedState)
     {
         $matchingTransitions = array();
 
-        foreach($this->transitions as $transition) {
+        foreach ($this->transitions as $transition) {
             if ($transition->getState() == $targetedState && in_array($initialState, $transition->getInitialStates())) {
                 $matchingTransitions[] = $transition;
             }
         }
 
         return $matchingTransitions;
+    }
+
+    /**
+     * Find the unique transition between initial and targeted states.
+     *
+     * @throws StateJumpException
+     *
+     * @param string $initialState
+     * @param string $targetedState
+     *
+     * @return TransitionInterface
+     */
+    private function resolveTransition($initialState, $targetedState)
+    {
+        if ($initialState == $targetedState) {
+            throw new NullJumpException();
+        }
+
+        $matchingTransitions = $this->getMatchingTransitions($initialState, $targetedState);
+
+        if ($matchingTransitions != 1) {
+            throw new AmbiguousJumpException();
+        }
+
+        return $matchingTransitions[0];
     }
 
     /**
@@ -45,20 +73,23 @@ class ExtendedStateMachine extends BaseExtendedStateMachine
         // assert that the given state exists
         $this->getState($state);
 
-        // state jumping to current state is allowed as it does nothing
-        if ($this->currentState->getName() == $state) {
+        try {
+            $transition = $this->resolveTransition($this->currentState->getName(), $state);
+            return $this->can($transition);
+        } catch (NullJumpException $ex) {
+            // state jumping to current state is allowed as it does nothing
             return true;
+        } catch (StateException $ex) {
+            return false;
         }
-
-        $transitions = $this->getMatchingTransitions($this->currentState->getName(), $state);
-
-        return count($transitions) == 1;
     }
 
     /**
      * Moves to the given state if allowed.
      *
      * @param string|StateInterface $state
+     *
+     * @return bool
      */
     public function jumpToState($state)
     {
@@ -67,15 +98,15 @@ class ExtendedStateMachine extends BaseExtendedStateMachine
         }
 
         if (!$this->canJumpToState($state)) {
-            throw new StateException(sprintf('Can not jump from state "%s" to "%s".',$this->currentState->getName(), $state->getName()));
+            throw new StateException(sprintf('Can not jump from state "%s" to "%s".', $this->currentState->getName(), $state->getName()));
         }
 
-        // do nothing if we try to jump to current state
-        if ($state == $this->currentState) {
+        try {
+            $transition = $this->resolveTransition($this->currentState->getName(), $state->getName());
+            return $this->apply($transition->getName());
+        } catch (NullJumpException $ex) {
+            // do nothing if we try to jump to current state
             return;
         }
-
-        $transitions = $this->getMatchingTransitions($this->currentState->getName(), $state);
-        $this->apply($transitions[0]->getName());
     }
 }


### PR DESCRIPTION
This pull request can introduce BC-BREAK.

When the state machine jumps from a `state A` to a `state B`, it doesn't use transition. It is a problem when there is logic (guards) behind transitions because the events and methods are not called. With this change it is no longer possible to jump between 2 states if there isn't a single direct transition between them.

In the documentation (README.MD), it imply that an article can jump from "reviewed" to "accepted" using the implicit "accept" transition, but cannot direct jump from "reviewed" to "publish". The article can jump to "rejected" from any state.

This way, the state graph is enforced.
