### PR TITLE
Lifecycle callbacks with a service

### DIFF
--- a/Listener/AbstractSubscriber.php
+++ b/Listener/AbstractSubscriber.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace KPhoen\DoctrineStateMachineBundle\Listener;
+
+use Doctrine\Common\Inflector\Inflector;
+use Finite\Event\FiniteEvents;
+use Finite\Event\StateMachineEvent;
+use Finite\Event\TransitionEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Implements "life callbacks" for stateful entities.
+ * The available callbacks are the following (all are optionnal):
+ *
+ *  * postInitialize:   called after the initial state is set ;
+ *
+ *  * can{Transition}:  called when the state machine checks if {Transition} can be applied.
+ *  * pre{Transition}:  called before the transition {Transition} is applied ; [DEPRECATED]
+ *  * post{Transition}: called after the transition {Transition} is applied ;
+ *
+ * @author alexandre
+ */
+abstract class AbstractSubscriber implements EventSubscriberInterface
+{
+    abstract public function supportsObject($object);
+
+    /**
+     * List of subscribed events
+     *
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FiniteEvents::SET_INITIAL_STATE => 'onSetInitialState',
+
+            FiniteEvents::TEST_TRANSITION => 'onTestTransition',
+            FiniteEvents::PRE_TRANSITION => 'onPreTransition',
+            FiniteEvents::POST_TRANSITION => 'onPostTransition',
+        );
+    }
+
+    public function onSetInitialState(StateMachineEvent $event)
+    {
+        $object = $event->getStateMachine()->getObject();
+        $result = $this->callCallback($object, 'can', 'initialize');
+
+        if ($result === false) {
+            throw new \Finite\Exception\StateException('State initialization has been rejected.');
+        }
+
+        $this->callCallback($object, 'post', 'initialize');
+    }
+
+    public function onTestTransition(TransitionEvent $event)
+    {
+        $object = $event->getStateMachine()->getObject();
+        $result = $this->callCallback($object, 'can', $event->getTransition()->getName());
+
+        if ($result === false) {
+            $event->reject();
+        }
+    }
+
+    /**
+     * @deprecated Can lead to errors
+     */
+    public function onPreTransition(TransitionEvent $event)
+    {
+        $object = $event->getStateMachine()->getObject();
+        $this->callCallback($object, 'pre', $event->getTransition()->getName());
+    }
+
+    public function onPostTransition(TransitionEvent $event)
+    {
+        $object = $event->getStateMachine()->getObject();
+        $this->callCallback($object, 'post', $event->getTransition()->getName());
+    }
+
+    /**
+     * Try to call a state lifecycle callback
+     *
+     * @param \KPhoen\DoctrineStateMachineBehavior\Entity\Stateful $object
+     * @param string $callbackPrefix
+     * @param string $transitionName
+     * @return mixed
+     */
+    protected function callCallback($object, $callbackPrefix, $transitionName)
+    {
+        $camelCasedName = Inflector::camelize($transitionName);
+        $methodName = $callbackPrefix . $camelCasedName;
+
+        if (!method_exists($this, $methodName)) {
+            return;
+        }
+
+        if (!$this->supportsObject($object)) {
+            return;
+        }
+
+        return call_user_func(array($this, $methodName), $object);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -211,9 +211,9 @@ use KPhoen\DoctrineStateMachineBundle\Listener\AbstractSubscriber;
 
 class ArticleSubscriber extends AbstractSubscriber
 {
-    public function getEntityClass()
+    public function supportsObject($object)
     {
-        return 'Acme\FooBundle\Entity\Article';
+        return $object instanceof \Acme\FooBundle\Entity\Article;
     }
 
     public function preAccept()

--- a/README.md
+++ b/README.md
@@ -186,6 +186,52 @@ class Article implements Stateful
 }
 ```
 
+### Using a service
+
+You can put the state logic outside of the entity using a listener on Finite
+events. The extension provides an abstract EventSubcriber with the same methods
+as the "lifecyle callbacks" listener.
+
+You need to declare a service and extend the AbstractSubcriber.
+
+```yaml
+services:
+    article_workflow_subscriber:
+        class: Acme\FooBundle\Workflow\ArticleSubscriber
+        tags:
+            - { name: kernel.event_subscriber }
+```
+
+```php
+<?php
+
+namespace Acme\FooBundle\Workflow;
+
+use KPhoen\DoctrineStateMachineBundle\Listener\AbstractSubscriber;
+
+class ArticleSubscriber extends AbstractSubscriber
+{
+    public function getEntityClass()
+    {
+        return 'Acme\FooBundle\Entity\Article';
+    }
+
+    public function preAccept()
+    {
+        // your logic here
+    }
+
+    public function postAccept()
+    {
+        // your logic here
+    }
+
+    public function canAccept()
+    {
+        // your logic here
+    }
+}
+```
 
 ## Twig
 
@@ -209,12 +255,12 @@ The bundle also exposes a few Twig helpers:
     </a>
 {% endif %}
 
-{% if article|isStatus('rejected') %}
+{% if article|is_status('rejected') %}
     blabla
 {% endif %}
 
 {# this is strictly equivalent #}
-{% if isStatus(article, 'rejected') %}
+{% if is_status(article, 'rejected') %}
     blabla
 {% endif %}
 ```


### PR DESCRIPTION
No BC-BREAK with this pull request.

I added an AbstractSubscriber to put state transition callbacks outside of the entity. I updated the documentation.

> You can put the state logic outside of the entity using a listener on Finite events. The extension provides an abstract EventSubcriber with the same methods as the "lifecyle callbacks" listener.
> 
> You need to declare a service and extend the AbstractSubcriber."