### PR TITLE
Remove call to deprecated twig class

### DIFF
--- a/Twig/StateMachineExtension.php
+++ b/Twig/StateMachineExtension.php
@@ -20,8 +20,8 @@ class StateMachineExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'can'       => new \Twig_Filter_Method($this, 'can'),
-            'isStatus'  => new \Twig_Filter_Method($this, 'isStatus'),
+            new \Twig_SimpleFilter('can', array($this, 'can')),
+            new \Twig_SimpleFilter('isStatus', array($this, 'isStatus')),
         );
     }
 


### PR DESCRIPTION
This PR updates the bundle's twig integration to use `Twig_SimpleFilter` instead of deprecated `Twig_Filter_Method`

This PR shouldn't pose any backwards compatibility issues.