### PR TITLE
Symfony >= 2.8 non-shared service definition

### DIFF
--- a/Resources/config/factories.yml
+++ b/Resources/config/factories.yml
@@ -16,4 +16,4 @@ services:
     kphoen.state_machine:
         class:      %kphoen.state_machine.class%
         arguments:  [ ~, @event_dispatcher ]
-        scope:      prototype
+        shared:     false


### PR DESCRIPTION
This solves the deprecation notice:

> The "scope" key of service "kphoen.state_machine" in file "factories.yml" is deprecated since version 2.8 and will be removed in 3.0

Docs relevant to the [deprecation of scopes][scope] and about [how to define non-shared services][ns-svc].

It is suggested that DoctrineStateMachineBundle is branched into Symfony <2.8 compatible and Symfony >= 2.8 compatible; this PR is for the latter branch.

[scope]: https://symfony.com/doc/2.8/cookbook/service_container/scopes.html
[ns-svc]: https://symfony.com/doc/master/cookbook/service_container/shared.html 
